### PR TITLE
Make JPEG still capture update buffer

### DIFF
--- a/esp32_camera_mjpeg_multiclient.ino
+++ b/esp32_camera_mjpeg_multiclient.ino
@@ -356,7 +356,8 @@ const int jhdLen = strlen(JHEADER);
 void handleJPG(void)
 {
   WiFiClient client = server.client();
-
+  
+  cam.run();
   if (!client.connected()) return;
   client.write(JHEADER, jhdLen);
   client.write((char*)cam.getfb(), cam.getSize());


### PR DESCRIPTION
Fixing problem on jpeg capture not being updated on each capture call.