### PR TITLE
Fixing issues with jpg endpoint

### DIFF
--- a/esp32_camera_mjpeg_multiclient.ino
+++ b/esp32_camera_mjpeg_multiclient.ino
@@ -359,9 +359,10 @@ void handleJPG(void)
   WiFiClient client = server.client();
 
   if (!client.connected()) return;
-  cam.run();
+  xSemaphoreTake( frameSync, portMAX_DELAY );
   client.write(JHEADER, jhdLen);
-  client.write((char*)cam.getfb(), cam.getSize());
+  client.write((char*) camBuf, (size_t)camSize);
+  xSemaphoreGive( frameSync );
 }
 
 


### PR DESCRIPTION
JPG endpoint used to initialize a new camera instance and take a snapshot. On some chips, this would cause the driver to error out and the entire camera to become unresponsive until a reboot. This change utilizes the frame held in the buffer and delivers it instead to prevent any errors.